### PR TITLE
fix location permission crash on getLastLocation invoked

### DIFF
--- a/LocationUpdatesForegroundService/app/build.gradle
+++ b/LocationUpdatesForegroundService/app/build.gradle
@@ -27,6 +27,6 @@ dependencies {
     compile 'com.android.support:appcompat-v7:26.1.0'
     testCompile 'junit:junit:4.12'
 
-    compile 'com.google.android.gms:play-services-location:11.0.0'
+    compile 'com.google.android.gms:play-services-location:15.0.1'
     compile 'com.android.support:design:26.1.0'
 }


### PR DESCRIPTION
[Issue #157](https://github.com/googlesamples/android-play-location/issues/157)

### Issue
Application crash LocationUpdateForegroundService
### Fix
bump play-services-location version 11.0.0->15.0.1