### PR TITLE
Updated Incorrect Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ This repo contains the following samples:
 
 - [LocationAddress](https://github.com/android/location-samples/tree/main/LocationAddress) (Java) - Use the [Geocode API](http://developer.android.com/reference/android/location/Geocoder.html) to display a device's location as an address.
 
-- [LocationAddressKotlin](https://github.com/android/location-samples/tree/main/LocationAddress) (Kotlin) - Same as above but in Kotlin.
+- [LocationAddressKotlin](https://github.com/android/location-samples/tree/main/LocationAddressKotlin) (Kotlin) - Same as above but in Kotlin.
 
 - [LocationUpdates](https://github.com/android/location-samples/tree/main/LocationUpdates) (Java) - Get updates about a device's location.
 
-- [LocationUpdatesBackgroundKotlin](https://github.com/android/location-samples/tree/main/LocationUpdatesBa) (Kotlin) - Demonstrates the correct way to retrieve location updates in the background.
+- [LocationUpdatesBackgroundKotlin](https://github.com/android/location-samples/tree/main/LocationUpdatesBackgroundKotlin) (Kotlin) - Demonstrates the correct way to retrieve location updates in the background.
 
 - [LocationUpdatesForegroundService](https://github.com/android/location-samples/tree/main/LocationUpdatesForegroundService) (Java) - Get updates about a device's location using a bound and started foreground service.
 


### PR DESCRIPTION
## Description

I have Updated the incorrect links one of them showed the java code sample instead of Kotlin code sample and another showes 404 error, seems like incomplete URL for it

## Changes Made

* Changed `LocationAddress` to `LocationAddressKotlin` for kotlin example at line number 23
* Changed Incorrect Link that shows 404 Page at Line number 27