### PR TITLE
Update README.md

### DIFF
--- a/AwarenessApisSampleKotlin/README.md
+++ b/AwarenessApisSampleKotlin/README.md
@@ -20,7 +20,7 @@ Developers can find more about this API and other Awareness APIs in our [Getting
 
 Users can request the current environment by pressing the "Request Snapshot" button.
 
-**IMPORTANT NOTE**: The Awareness APIs (both Snapshot and Fend) require an API key in your manifest.
+**IMPORTANT NOTE**: The Awareness APIs (both Snapshot and Fence) require an API key in your manifest.
 Check [this link][3] for more information.
 
 [1]: https://developers.google.com/android/reference/com/google/android/gms/awareness/Awareness#getSnapshotClient(android.app.Activity)


### PR DESCRIPTION
I noticed that there is a typo in line #23.

line 23:  The Awareness APIs (both Snapshot and Fend) require an API key in your manifest.

#fix proposed in this PR, it should be 'Fence' (one of the two The Awareness APIs) in place of 'Fend'