### PR TITLE
fix: activity recognition build and dependencies

### DIFF
--- a/ActivityRecognition/app/build.gradle
+++ b/ActivityRecognition/app/build.gradle
@@ -22,12 +22,12 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.google.android.gms.location.sample.activityrecognition"
         minSdk 21
-        targetSdk 31
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -50,14 +50,13 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
-        useIR = true
     }
     buildFeatures {
         compose true
     }
     composeOptions {
         kotlinCompilerExtensionVersion compose_version
-        kotlinCompilerVersion '1.5.10'
+        kotlinCompilerVersion '1.7.0'
     }
     packagingOptions {
         resources {
@@ -73,8 +72,9 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation "androidx.datastore:datastore-preferences:1.0.0"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0'
-    implementation 'androidx.activity:activity-compose:1.4.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.0'
+    implementation 'androidx.activity:activity-compose:1.5.0'
 
     implementation 'com.google.android.material:material:1.5.0'
 

--- a/ActivityRecognition/build.gradle
+++ b/ActivityRecognition/build.gradle
@@ -1,10 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = '1.0.0'
-        coroutine_version = '1.6.0'
+        compose_version = '1.2.0'
+        coroutine_version = '1.6.4'
         hilt_compiler_version = '1.0.0'
-        hilt_version = '2.38.1'
+        hilt_version = '2.45'
         room_version = "2.4.1"
     }
     repositories {
@@ -12,8 +12,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.0.4"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.10"
+        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/ActivityRecognition/gradle/wrapper/gradle-wrapper.properties
+++ b/ActivityRecognition/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jan 31 10:02:26 PST 2022
+#Thu Mar 23 18:41:13 CET 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The ActivityRecognition project doesn't work due to two reasons:

1) Some of the configuration options for Kotlin inside build.gradle are deprecated. Changing the Kotlin version can cause the compose-hilt-kotlin libraries to have different dependency versions, which can lead to a Gradle failure.
2) The Hilt version needs to upgrade some activity and lifecycle components. For more information, please see this Stack Overflow thread: https://stackoverflow.com/questions/73302605/creationextras-must-have-a-value-by-saved-state-registry-owner-key.

This pull requests updates and fixes the dependencies.
