### PR TITLE
Updated pending intent as per Android 12 

### DIFF
--- a/SleepSampleKotlin/app/src/main/java/com/android/example/sleepsamplekotlin/receiver/SleepReceiver.kt
+++ b/SleepSampleKotlin/app/src/main/java/com/android/example/sleepsamplekotlin/receiver/SleepReceiver.kt
@@ -94,8 +94,11 @@ class SleepReceiver : BroadcastReceiver() {
                 context,
                 0,
                 sleepIntent,
-                PendingIntent.FLAG_CANCEL_CURRENT
+                getPendingIntentFlag()
             )
         }
+        fun getPendingIntentFlag() = PendingIntent.FLAG_CANCEL_CURRENT or
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) PendingIntent.FLAG_MUTABLE
+                else 0
     }
 }


### PR DESCRIPTION
Hi, an explicit mention of pending intent flags is needed from API level 31 or higher for FLAG_MUTABLE or FLAG_IMMUTABLE. I have updated it accordingly.
Thanks!